### PR TITLE
Fixed bug where spawners wouldn't give XP after being moved

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.soerxpso</groupId>
   <artifactId>XPSpawners</artifactId>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <packaging>jar</packaging>
 
   <name>XPSpawners</name>

--- a/src/main/java/com/github/soerxpso/xpspawners/listeners/BlockListener.java
+++ b/src/main/java/com/github/soerxpso/xpspawners/listeners/BlockListener.java
@@ -2,12 +2,14 @@ package com.github.soerxpso.xpspawners.listeners;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.block.CreatureSpawner;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockExplodeEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.scheduler.BukkitRunnable;
 
@@ -22,6 +24,17 @@ public class BlockListener implements Listener {
 	
 	public BlockListener() {
 		spawnerManager = XPSpawners.getPlugin().getSpawnerManager();
+	}
+	
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	public void onBlockInteract(PlayerInteractEvent e) {
+		Block b = e.getClickedBlock();
+		if(b.getType() == Material.MOB_SPAWNER) {
+			Spawner spawner = spawnerManager.getSpawner(b.getLocation());
+			if(spawner == null) {
+				spawnerManager.addSpawner(new Spawner((CreatureSpawner)b));
+			}
+		}
 	}
 
 	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
@@ -47,7 +60,9 @@ public class BlockListener implements Listener {
 	
 	@EventHandler
 	public void onBlockExplode(BlockExplodeEvent e) {
-		
+		if(e.getBlock().getType() == Material.MOB_SPAWNER) {
+			removeSpawner(e.getBlock());
+		}
 	}
 	
 	private void removeSpawner(Block b) {

--- a/src/main/java/com/github/soerxpso/xpspawners/listeners/MobSpawnListener.java
+++ b/src/main/java/com/github/soerxpso/xpspawners/listeners/MobSpawnListener.java
@@ -18,7 +18,7 @@ public class MobSpawnListener implements Listener {
 		this.spawnerManager = XPSpawners.getPlugin().getSpawnerManager();
 	}
 	
-	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = false)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onMobSpawn(SpawnerSpawnEvent e) {
 		e.setCancelled(true);
 		


### PR DESCRIPTION
The bug was caused because no MobSpawnEvent would happen (since the spawners were pig spawners), which meant spawners wouldn't be recognized by the plugin. Players can now right-click spawners that aren't working in order to register them (they'll only need to do this once every time the map is reloaded). A less temporary fix will be added in version 1.2.
