### PR TITLE
Center spawners on the center of the block instead of the integer block coord

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.github.soerxpso</groupId>
   <artifactId>XPSpawners</artifactId>
-  <version>1.0.14</version>
+  <version>1.0.15</version>
   <packaging>jar</packaging>
 
   <name>XPSpawners</name>
@@ -45,8 +45,8 @@
       <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
     </repository>
     <repository>
-      <id>civcraft-repo</id>
-      <url>http://build.civcraft.co:8080/plugin/repository/everything/</url>
+      <id>devoted-repo</id>
+      <url>http://build.devotedmc.com/plugin/repository/everything/</url>
     </repository>
 </repositories>
 

--- a/src/main/java/com/github/soerxpso/xpspawners/Spawner.java
+++ b/src/main/java/com/github/soerxpso/xpspawners/Spawner.java
@@ -21,7 +21,8 @@ public class Spawner implements QTBox, Comparable<Spawner> {
 	private int xpAmountPerHarvest;
 	
 	public Spawner(CreatureSpawner block) {
-		this.location = block.getLocation().clone();
+		Location blockLoc = block.getLocation();
+		this.location = new Location(blockLoc.getWorld(), blockLoc.getX() + 0.5, blockLoc.getY() + 0.5, blockLoc.getZ() + 0.5);
 		this.xpAmountPerHarvest = (int) (ConfigManager.getBaseXpPerHour() / 60f / 60f / 20f 
 				* ConfigManager.getHarvestInterval());
 	}

--- a/src/main/java/com/github/soerxpso/xpspawners/XPSpawners.java
+++ b/src/main/java/com/github/soerxpso/xpspawners/XPSpawners.java
@@ -34,6 +34,9 @@ public class XPSpawners extends JavaPlugin {
 	
 	public void givePlayersXP() {
 		for(Player p : getServer().getOnlinePlayers()) {
+			if (p.isDead()) {
+				continue;
+			}
 			Spawner s = spawnerManager.nearestSpawner(p.getLocation());
 			if(s == null) continue;
 			getLogger().log(Level.FINE, "Nearest spawner to " + p + " is at " + s.getLocation());

--- a/src/main/java/com/github/soerxpso/xpspawners/manager/SpawnerManager.java
+++ b/src/main/java/com/github/soerxpso/xpspawners/manager/SpawnerManager.java
@@ -42,7 +42,13 @@ public class SpawnerManager {
 	public Spawner getSpawner(Location loc) {
 		Spawner s = nearestSpawner(loc);
 		if(s == null) return null;
-		if(s.getLocation().equals(loc)) return s;
+		//the spawners internal location is not actually the block location, but the block location increased by 0.5 on every
+		//coordinate, so the location used for range checks is at the actual center of the block, which we need to take into
+		//account here with a check that might seem overly complicated
+		Location spaLoc = s.getLocation();
+		if(spaLoc.getBlock().getLocation().equals(loc.getBlock().getLocation())) {
+			return s;
+		}
 		return null;
 	}
 	


### PR DESCRIPTION
Currently distance checks to spawners are done based on the block coordinate of the spawners, which will always be in the same corner of the block (I think it's northwest) and not at the actual center of the spawners. This messes up the actual distance to the spawner by up to an entire block, based on the direction in which you are standing away from it, as it will think one player is half a block closer than he actually is and another half a block further away than he actually is.

We can fix this by using the actual center of the block as location for range checks, which we do by adding 0.5 to every coordinate.